### PR TITLE
add/fix: YankEndOfLine and YankIntoRegister tasks

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -85,6 +85,8 @@ training.setup({
 		"MoveStartOfFile",
 		"SearchForward",
 		"Increment",
+		"YankEndOfLine",
+		"YankIntoRegister",
 	},
 	task_scheduler = "RandomScheduler",
 })

--- a/Readme.md
+++ b/Readme.md
@@ -59,6 +59,11 @@ safe you may start in an empty buffer/directory.
 | -------- | -------- | -------- |
 | SearchForward| Search for target-string forwards. |
 
+## Text Manipulation
+| Name | Description | Notes |
+| -------- | -------- | -------- |
+| YankEndOfLine| Copy text from the cursor to the end of the line. |
+| YankIntoRegister| Copy text into a specified register. |
 
 ## Miscelaneous
 

--- a/lua/nvim-training/task_index.lua
+++ b/lua/nvim-training/task_index.lua
@@ -5,7 +5,7 @@ local MoveEndOfFile = require("nvim-training.tasks.move_end_of_file")
 local SearchForward = require("nvim-training.tasks.search_forward")
 local Increment = require("nvim-training.tasks.increment")
 local YankEndOfLine = require("nvim-training.tasks.yank_end_of_line")
-local YankIntoRegisterTask = require("nvim-training.tasks.yank_into_register")
+local YankIntoRegister = require("nvim-training.tasks.yank_into_register")
 
 local exported_tasks = {
 	MoveEndOfLine = MoveEndOfLine,
@@ -15,7 +15,7 @@ local exported_tasks = {
 	MoveStartOfFile = MoveStartOfFile,
 	Increment = Increment,
 	YankEndOfLine = YankEndOfLine,
-	YankIntoRegisterTask = YankIntoRegisterTask,
+	YankIntoRegister = YankIntoRegister,
 }
 
 for i, v in pairs(exported_tasks) do

--- a/lua/nvim-training/task_index.lua
+++ b/lua/nvim-training/task_index.lua
@@ -4,6 +4,7 @@ local MoveStartOfFile = require("nvim-training.tasks.move_start_of_file")
 local MoveEndOfFile = require("nvim-training.tasks.move_end_of_file")
 local SearchForward = require("nvim-training.tasks.search_forward")
 local Increment = require("nvim-training.tasks.increment")
+local YankEndOfLine = require("nvim-training.tasks.yank_end_of_line")
 
 local exported_tasks = {
 	MoveEndOfLine = MoveEndOfLine,
@@ -12,6 +13,7 @@ local exported_tasks = {
 	MoveEndOfFile = MoveEndOfFile,
 	MoveStartOfFile = MoveStartOfFile,
 	Increment = Increment,
+	YankEndOfLine = YankEndOfLine,
 }
 
 for i, v in pairs(exported_tasks) do

--- a/lua/nvim-training/task_index.lua
+++ b/lua/nvim-training/task_index.lua
@@ -5,6 +5,7 @@ local MoveEndOfFile = require("nvim-training.tasks.move_end_of_file")
 local SearchForward = require("nvim-training.tasks.search_forward")
 local Increment = require("nvim-training.tasks.increment")
 local YankEndOfLine = require("nvim-training.tasks.yank_end_of_line")
+local YankIntoRegisterTask = require("nvim-training.tasks.yank_into_register")
 
 local exported_tasks = {
 	MoveEndOfLine = MoveEndOfLine,
@@ -14,6 +15,7 @@ local exported_tasks = {
 	MoveStartOfFile = MoveStartOfFile,
 	Increment = Increment,
 	YankEndOfLine = YankEndOfLine,
+	YankIntoRegisterTask = YankIntoRegisterTask,
 }
 
 for i, v in pairs(exported_tasks) do

--- a/lua/nvim-training/tasks/yank.lua
+++ b/lua/nvim-training/tasks/yank.lua
@@ -11,9 +11,10 @@ end
 function YankTask:teardown(autocmd_callback_data)
 	-- local event_data = vim.deepcopy(vim.v.event)
 	-- print(self.target_text, "--", event_data.regcontents[1])
-	local clipboard_content = vim.fn.getreg('"')
+	local register = self.chosen_register or ''
+	local register_content = vim.fn.getreg('"' .. register)
 
-	local yank_success = self.target_text == clipboard_content
+	local yank_success = self.target_text == register_content
 	return yank_success
 	-- return event_data.regcontents[1] == self.target_text
 end

--- a/lua/nvim-training/tasks/yank.lua
+++ b/lua/nvim-training/tasks/yank.lua
@@ -9,9 +9,13 @@ function YankTask:new()
 	return base
 end
 function YankTask:teardown(autocmd_callback_data)
-	local event_data = vim.deepcopy(vim.v.event)
+	-- local event_data = vim.deepcopy(vim.v.event)
 	-- print(self.target_text, "--", event_data.regcontents[1])
-	return event_data.regcontents[1] == self.target_text
+	local clipboard_content = vim.fn.getreg('"')
+
+	local yank_success = self.target_text == clipboard_content
+	return yank_success
+	-- return event_data.regcontents[1] == self.target_text
 end
 
 return YankTask

--- a/lua/nvim-training/tasks/yank_end_of_line.lua
+++ b/lua/nvim-training/tasks/yank_end_of_line.lua
@@ -1,6 +1,6 @@
 local utility = require("nvim-training.utility")
-local user_config = require("nvim-training.user_config")
-local YankTask = require("nvim-training.tasks.yank_task")
+local internal_config = require("nvim-training.internal_config")
+local YankTask = require("nvim-training.tasks.yank")
 
 local YankEndOfLine = YankTask:new()
 YankEndOfLine.__index = YankEndOfLine
@@ -13,7 +13,7 @@ function YankEndOfLine:new()
 	self.autocmd = "TextYankPost"
 	local function _inner_update()
 		utility.set_buffer_to_lorem_ipsum_and_place_cursor_randomly()
-		local x_start = math.random(3) + user_config.header_length
+		local x_start = math.random(3) + internal_config.header_length
 		local y_start = math.random(3, 15)
 		local lines = vim.api.nvim_buf_get_lines(0, x_start - 1, vim.api.nvim_buf_line_count(0), false)
 		self.target_text = string.sub(lines[1], y_start + 1, #lines[1])

--- a/lua/nvim-training/tasks/yank_into_register.lua
+++ b/lua/nvim-training/tasks/yank_into_register.lua
@@ -1,18 +1,19 @@
-local Task = require("nvim-training.task")
 local utility = require("nvim-training.utility")
 local user_config = require("nvim-training.user_config")
+local YankTask = require("nvim-training.tasks.yank")
 
-local YankIntoRegisterTask = {}
+local YankIntoRegisterTask = YankTask:new()
 YankIntoRegisterTask.__index = YankIntoRegisterTask
 
-function YankIntoRegisterTask:setup()
-	local base = Task:new()
+function YankIntoRegisterTask:new()
+	local base = YankTask:new()
 	setmetatable(base, { __index = YankIntoRegisterTask })
 
-	self.target_line = 0
+	-- self.target_line = 0
 	self.autocmd = "TextYankPost"
 	self.possible_registers = user_config.possible_register_list
-	self.choosen_register = self.possible_registers[#self.possible_register_list]
+	self.chosen_register = self.possible_registers[#self.possible_registers]
+	
 	local function _inner_update()
 		utility.set_buffer_to_lorem_ipsum_and_place_cursor_randomly()
 
@@ -21,18 +22,15 @@ function YankIntoRegisterTask:setup()
 		local lines = vim.api.nvim_buf_get_lines(0, cursor_pos[1] - 1, cursor_pos[1], false)
 		local line_length = #lines[1]
 		self.highlight = utility.create_highlight(cursor_pos[1] - 1, cursor_pos[2], line_length)
+		
+		self.target_text = lines[1] .. "\n"
 	end
 	vim.schedule_wrap(_inner_update)()
 	return base
 end
 
-function YankIntoRegisterTask:teardown(autocmd_callback_data)
-	utility.clear_highlight(self.highlight)
-	return false
-end
-
 function YankIntoRegisterTask:description()
-	return "Copy the line the cursor is in into register " .. self.choosen_register
+	return "Copy the line the cursor is in into register " .. self.chosen_register
 end
 
 return YankIntoRegisterTask

--- a/lua/nvim-training/tasks/yank_into_register.lua
+++ b/lua/nvim-training/tasks/yank_into_register.lua
@@ -2,12 +2,12 @@ local utility = require("nvim-training.utility")
 local user_config = require("nvim-training.user_config")
 local YankTask = require("nvim-training.tasks.yank")
 
-local YankIntoRegisterTask = YankTask:new()
-YankIntoRegisterTask.__index = YankIntoRegisterTask
+local YankIntoRegister = YankTask:new()
+YankIntoRegister.__index = YankIntoRegister
 
-function YankIntoRegisterTask:new()
+function YankIntoRegister:new()
 	local base = YankTask:new()
-	setmetatable(base, { __index = YankIntoRegisterTask })
+	setmetatable(base, { __index = YankIntoRegister })
 
 	-- self.target_line = 0
 	self.autocmd = "TextYankPost"
@@ -29,8 +29,8 @@ function YankIntoRegisterTask:new()
 	return base
 end
 
-function YankIntoRegisterTask:description()
+function YankIntoRegister:description()
 	return "Copy the line the cursor is in into register " .. self.chosen_register
 end
 
-return YankIntoRegisterTask
+return YankIntoRegister

--- a/lua/nvim-training/tasks/yank_into_register.lua
+++ b/lua/nvim-training/tasks/yank_into_register.lua
@@ -12,7 +12,7 @@ function YankIntoRegister:new()
 	-- self.target_line = 0
 	self.autocmd = "TextYankPost"
 	self.possible_registers = user_config.possible_register_list
-	self.chosen_register = self.possible_registers[#self.possible_registers]
+	self.chosen_register = self.possible_registers[math.random(#self.possible_registers)]
 	
 	local function _inner_update()
 		utility.set_buffer_to_lorem_ipsum_and_place_cursor_randomly()


### PR DESCRIPTION
## What's Changed

- `YankEndOfLine` and `YankIntoRegister` tasks are competed and added to the task index.
- Readme updated accordingly.

## Why These Changes?

Picked up these partially done features as a way to get more familiar with the project and Neovim API. They seemed like the right place to start as a junior Neovim user, making the plugin more engaging.

## Looking Forward

Happy to make further tweaks based on feedback. Excited to contribute more down the line!

---

Feel free to reach out with any suggestions for improvement. Thanks for checking out these updates!
