### PR TITLE
Chore: Deletes some prints and 'using'

### DIFF
--- a/lua/nvim-training/movements.lua
+++ b/lua/nvim-training/movements.lua
@@ -6,7 +6,6 @@ function movements.end_of_line(line, cursor_pos)
 end
 
 local function move_across_word_pos(line, cursor_pos, word_calc_func, counter)
-	print(vim.inspect(line), vim.inspect(cursor_pos), counter)
 	local word_positions = word_calc_func(line)
 	local word_index_cursor = utility.calculate_word_index_from_cursor_pos(word_positions, cursor_pos)
 

--- a/lua/nvim-training/tasks/Paste.lua
+++ b/lua/nvim-training/tasks/Paste.lua
@@ -35,7 +35,7 @@ function Paste:deactivate()
 end
 
 function Paste:instructions()
-	return "Paste the text from register '" .. self.choosen_reg .. "' into the line above the current using P"
+	return "Paste the text from register '" .. self.choosen_reg .. "' into the line above the current."
 end
 
 return Paste

--- a/lua/nvim-training/tasks/change_word.lua
+++ b/lua/nvim-training/tasks/change_word.lua
@@ -46,7 +46,7 @@ function ChangeWord:activate()
 end
 
 function ChangeWord:instructions()
-	return "Change the text of " .. self.counter .. " word(s) (using w,c) into '" .. self.text_to_be_inserted .. "'."
+	return "Change the text of " .. self.counter .. " word(s) into '" .. self.text_to_be_inserted .. "'."
 end
 
 return ChangeWord

--- a/lua/nvim-training/tasks/delete.lua
+++ b/lua/nvim-training/tasks/delete.lua
@@ -15,7 +15,6 @@ end
 function Delete:deactivate()
 	local register_content = vim.fn.getreg('"')
 	register_content = utility.split_str(register_content, "\n")[1]
-	print("--", register_content, "--", self.target_text, "--", #register_content, " ", #self.target_text)
 	return self.target_text == register_content
 end
 

--- a/lua/nvim-training/tasks/delete_WORD.lua
+++ b/lua/nvim-training/tasks/delete_WORD.lua
@@ -42,6 +42,6 @@ function DeleteWORD:activate()
 end
 
 function DeleteWORD:instructions()
-	return "Delete " .. self.counter .. " word(s) using 'W'."
+	return "Delete " .. self.counter .. " WORDS(s)."
 end
 return DeleteWORD

--- a/lua/nvim-training/tasks/delete_f.lua
+++ b/lua/nvim-training/tasks/delete_f.lua
@@ -44,7 +44,7 @@ function Deletef:activate()
 end
 
 function Deletef:instructions()
-	return "Delete to the char '" .. self.target_char .. "' using f."
+	return "Delete to the char '" .. self.target_char .. "'."
 end
 
 return Deletef

--- a/lua/nvim-training/tasks/delete_word.lua
+++ b/lua/nvim-training/tasks/delete_word.lua
@@ -43,6 +43,6 @@ function DeleteWord:activate()
 end
 
 function DeleteWord:instructions()
-	return "Delete " .. self.counter .. " word(s) using 'w'."
+	return "Delete " .. self.counter .. " word(s)."
 end
 return DeleteWord

--- a/lua/nvim-training/tasks/move_T_task.lua
+++ b/lua/nvim-training/tasks/move_T_task.lua
@@ -57,7 +57,7 @@ function MoveT:deactivate(autocmd_args)
 end
 
 function MoveT:instructions()
-	return "Move to the char '" .. self.target_char .. "' using F."
+	return "Move to the char '" .. self.target_char .. "'."
 end
 
 return MoveT

--- a/lua/nvim-training/tasks/move_WORD.lua
+++ b/lua/nvim-training/tasks/move_WORD.lua
@@ -33,6 +33,6 @@ function MoveWORD:activate()
 end
 
 function MoveWORD:instructions()
-	return "Move " .. self.counter .. " WORD(s) using 'W'."
+	return "Move " .. self.counter .. " WORD(s)."
 end
 return MoveWORD

--- a/lua/nvim-training/tasks/move_lines_up.lua
+++ b/lua/nvim-training/tasks/move_lines_up.lua
@@ -35,7 +35,6 @@ function MoveLinesUp:activate()
 		vim.api.nvim_win_set_cursor(0, { x_center, cursor_pos[2] })
 		self.cursor_target = { x_center - self.counter, cursor_pos[2] }
 		utility.construct_highlight(self.cursor_target[1], 0, #utility.get_line(self.cursor_target[1]))
-		print(self.counter, x_center, x_limit)
 	end
 	vim.schedule_wrap(_inner_update)()
 end

--- a/lua/nvim-training/tasks/move_word.lua
+++ b/lua/nvim-training/tasks/move_word.lua
@@ -33,7 +33,7 @@ function MoveWord:activate()
 end
 
 function MoveWord:instructions()
-	return "Move " .. self.counter .. " word(s) using 'w'."
+	return "Move " .. self.counter .. " word(s)."
 end
 
 return MoveWord

--- a/lua/nvim-training/tasks/paste.lua
+++ b/lua/nvim-training/tasks/paste.lua
@@ -35,7 +35,7 @@ function paste:deactivate()
 end
 
 function paste:instructions()
-	return "Paste the text from register '" .. self.choosen_reg .. "' into the next line using p."
+	return "Paste the text from register '" .. self.choosen_reg .. "' into the next line."
 end
 
 return paste

--- a/lua/nvim-training/tasks/yank_WORD.lua
+++ b/lua/nvim-training/tasks/yank_WORD.lua
@@ -43,7 +43,7 @@ function YankWORD:activate()
 end
 
 function YankWORD:instructions()
-	return "Yank " .. self.counter .. " WORDS(s) using 'W'."
+	return "Yank " .. self.counter .. " WORDS(s)."
 end
 
 return YankWORD

--- a/lua/nvim-training/tasks/yank_word.lua
+++ b/lua/nvim-training/tasks/yank_word.lua
@@ -44,7 +44,7 @@ function YankWord:activate()
 end
 
 function YankWord:instructions()
-	return "Yank " .. self.counter .. " word(s) using 'w'."
+	return "Yank " .. self.counter .. " word(s)."
 end
 
 return YankWord


### PR DESCRIPTION
The previous commits left some prints in
the codebase. These have been removed.

Furhtermore, some tasks had a tooltip build in.
These tips have been removed to keep the instructions concise.